### PR TITLE
cleanup file go

### DIFF
--- a/cleanup_mock_users.go
+++ b/cleanup_mock_users.go
@@ -1,0 +1,325 @@
+//go:build ignore
+
+// ============================================================================
+// cleanup_mock_users.go
+// ============================================================================
+// One-off script to delete the ~3,000 mock users created against the hosted
+// DB by closevia/clovia-performance-test.js (k6 load test). Each k6 iteration
+// registers a new account, so the rows look like:
+//
+//   name      = 'Performance Test User'   (clovia-performance-test.js:167)
+//   email     = 'testuser-<ms>-<rand>@test.com'  (clovia-performance-test.js:65)
+//   verified  = 0    (k6 never runs the OTP flow)
+//   role      = 'user'
+//
+// All four conditions must match — defense in depth so we don't accidentally
+// touch a real user.
+//
+// Run flow:
+//
+//   1) DRY RUN (default — no changes):
+//        go run cleanup_mock_users.go
+//      Inspect the printed counts. suspicious_matches MUST be 0. The sample
+//      rows MUST all look like Performance Test User accounts.
+//
+//   2) ACTUAL CLEANUP (only after dry run looks correct AND an Aiven backup
+//      has been taken):
+//        go run cleanup_mock_users.go --confirm
+//      This wraps everything in a transaction. If the post-delete safety
+//      check fails (remaining_mock_users != 0), the script ROLLS BACK
+//      automatically. On success it COMMITs.
+//
+// Cascade order mirrors handlers/user_handler.go:1856-1865 (the DeleteUser
+// handler) — replicated here in case the hosted DB is missing some
+// ON DELETE CASCADE constraints, since the hosted schema is known to drift
+// from local migrations in places.
+// ============================================================================
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/joho/godotenv"
+	"github.com/xashathebest/clovia/database"
+)
+
+func main() {
+	confirm := flag.Bool("confirm", false, "Actually run the DELETE block inside a transaction. Without this flag the script only prints the dry-run inspection.")
+	flag.Parse()
+
+	if err := godotenv.Load(); err != nil {
+		log.Println("No .env file found, relying on environment variables")
+	}
+	if err := database.InitDatabase(); err != nil {
+		log.Fatal("Failed to init DB: ", err)
+	}
+	defer database.CloseDatabase()
+
+	fmt.Println("============================================================")
+	fmt.Println("CLEANUP: k6 'Performance Test User' rows")
+	fmt.Println("============================================================")
+	if *confirm {
+		fmt.Println("Mode: COMMIT (will run transactional DELETE)")
+	} else {
+		fmt.Println("Mode: DRY RUN (no changes will be made)")
+		fmt.Println("Pass --confirm to actually run the cleanup.")
+	}
+	fmt.Println()
+
+	if err := dryRun(database.DB); err != nil {
+		log.Fatal("Dry run failed: ", err)
+	}
+
+	if !*confirm {
+		fmt.Println()
+		fmt.Println("DRY RUN COMPLETE.")
+		fmt.Println("If the numbers above look right, re-run with --confirm to execute the cleanup.")
+		return
+	}
+
+	fmt.Println()
+	if err := runCleanup(database.DB); err != nil {
+		log.Fatal("Cleanup failed: ", err)
+	}
+}
+
+// dryRun prints what WOULD be deleted without making any changes.
+// It exits with status 1 if the suspicious_matches sanity check fails.
+func dryRun(db *sql.DB) error {
+	const targetWhere = `name = 'Performance Test User'
+		  AND email LIKE 'testuser-%@test.com'
+		  AND verified = 0
+		  AND role = 'user'`
+
+	// 1a. How many users will be targeted?
+	var willDelete int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM users WHERE ` + targetWhere).Scan(&willDelete); err != nil {
+		return fmt.Errorf("1a will_delete_users: %w", err)
+	}
+	fmt.Printf("1a. will_delete_users      = %d\n", willDelete)
+
+	// 1b. Sanity check: any matching name+email row that is NOT unverified+user-role?
+	//     If this is > 0, something matches our pattern that we did NOT expect — STOP.
+	var suspicious int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM users
+		WHERE name = 'Performance Test User'
+		  AND email LIKE 'testuser-%@test.com'
+		  AND (verified = 1 OR role <> 'user')
+	`).Scan(&suspicious); err != nil {
+		return fmt.Errorf("1b suspicious_matches: %w", err)
+	}
+	fmt.Printf("1b. suspicious_matches     = %d   (MUST be 0)\n", suspicious)
+	if suspicious > 0 {
+		fmt.Println()
+		fmt.Println("STOP: suspicious matches found.")
+		fmt.Println("A row matches name+email but is verified or has a non-user role.")
+		fmt.Println("Investigate manually before re-running.")
+		os.Exit(1)
+	}
+
+	// 1c. 10 sample rows so a human can eyeball them.
+	fmt.Println()
+	fmt.Println("1c. sample rows (latest 10):")
+	rows, err := db.Query(`
+		SELECT id, name, email, verified, role, created_at FROM users
+		WHERE ` + targetWhere + `
+		ORDER BY id DESC
+		LIMIT 10
+	`)
+	if err != nil {
+		return fmt.Errorf("1c sample rows: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, verified int
+		var name, email, role, createdAt string
+		if err := rows.Scan(&id, &name, &email, &verified, &role, &createdAt); err != nil {
+			return fmt.Errorf("1c scan: %w", err)
+		}
+		fmt.Printf("    id=%d  name=%q  email=%q  verified=%d  role=%s  created_at=%s\n",
+			id, name, email, verified, role, createdAt)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("1c rows.Err: %w", err)
+	}
+
+	// 1d. Downstream cascade counts.
+	fmt.Println()
+	fmt.Println("1d. downstream cascade counts:")
+	targetSubquery := `(SELECT id FROM users WHERE ` + targetWhere + `)`
+
+	var products, trades, notifications int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM products WHERE seller_id IN ` + targetSubquery).Scan(&products); err != nil {
+		return fmt.Errorf("1d products: %w", err)
+	}
+	fmt.Printf("    products_to_delete      = %d\n", products)
+
+	if err := db.QueryRow(`SELECT COUNT(*) FROM trades WHERE buyer_id IN ` + targetSubquery + ` OR seller_id IN ` + targetSubquery).Scan(&trades); err != nil {
+		return fmt.Errorf("1d trades: %w", err)
+	}
+	fmt.Printf("    trades_to_delete        = %d\n", trades)
+
+	if err := db.QueryRow(`SELECT COUNT(*) FROM notifications WHERE user_id IN ` + targetSubquery).Scan(&notifications); err != nil {
+		return fmt.Errorf("1d notifications: %w", err)
+	}
+	fmt.Printf("    notifications_to_delete = %d\n", notifications)
+
+	return nil
+}
+
+// runCleanup performs the actual transactional delete. It always uses a
+// single connection (via *sql.Tx) so the TEMPORARY TABLE is visible across
+// every statement. On any error, or if the post-delete safety check fails,
+// it rolls back and returns an error.
+func runCleanup(db *sql.DB) error {
+	fmt.Println("============================================================")
+	fmt.Println("STEP 2 — TRANSACTIONAL CLEANUP")
+	fmt.Println("============================================================")
+
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+
+	// Track whether we've already finalized (commit/rollback) so the deferred
+	// rollback is a no-op on the success path.
+	finalized := false
+	defer func() {
+		if !finalized {
+			if rbErr := tx.Rollback(); rbErr != nil && rbErr != sql.ErrTxDone {
+				fmt.Printf("rollback error: %v\n", rbErr)
+			}
+		}
+	}()
+
+	// Stage target IDs into a TEMPORARY TABLE. This both speeds up the
+	// downstream DELETEs (no re-running the WHERE on every step) and locks
+	// the working set so it can't drift mid-transaction if k6 ran again.
+	if _, err := tx.ExecContext(ctx, `DROP TEMPORARY TABLE IF EXISTS _mock_user_ids`); err != nil {
+		return fmt.Errorf("drop temp table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE TEMPORARY TABLE _mock_user_ids (id INT PRIMARY KEY) ENGINE=MEMORY`); err != nil {
+		return fmt.Errorf("create temp table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO _mock_user_ids (id)
+		SELECT id FROM users
+		WHERE name = 'Performance Test User'
+		  AND email LIKE 'testuser-%@test.com'
+		  AND verified = 0
+		  AND role = 'user'
+	`); err != nil {
+		return fmt.Errorf("populate temp table: %w", err)
+	}
+
+	var staged int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM _mock_user_ids`).Scan(&staged); err != nil {
+		return fmt.Errorf("count staged: %w", err)
+	}
+	fmt.Printf("staged_user_ids = %d\n\n", staged)
+
+	if staged == 0 {
+		fmt.Println("Nothing to delete. Rolling back (no-op).")
+		_ = tx.Rollback()
+		finalized = true
+		return nil
+	}
+
+	// Delete order mirrors handlers/user_handler.go:1856-1865 exactly.
+	steps := []struct {
+		label string
+		stmt  string
+	}{
+		{
+			"2a. trade_items via products",
+			`DELETE ti FROM trade_items ti
+			 JOIN products p ON p.id = ti.product_id
+			 WHERE p.seller_id IN (SELECT id FROM _mock_user_ids)`,
+		},
+		{
+			"2b. multiway_trades",
+			`DELETE FROM multiway_trades
+			 WHERE user1_id          IN (SELECT id FROM _mock_user_ids)
+			    OR user2_id          IN (SELECT id FROM _mock_user_ids)
+			    OR user3_id          IN (SELECT id FROM _mock_user_ids)
+			    OR initiator_user_id IN (SELECT id FROM _mock_user_ids)`,
+		},
+		{
+			"2c. trade_loop_agreements",
+			`DELETE FROM trade_loop_agreements
+			 WHERE user_id IN (SELECT id FROM _mock_user_ids)`,
+		},
+		{
+			"2d. trades",
+			`DELETE FROM trades
+			 WHERE buyer_id  IN (SELECT id FROM _mock_user_ids)
+			    OR seller_id IN (SELECT id FROM _mock_user_ids)`,
+		},
+		{
+			"2e. products",
+			`DELETE FROM products
+			 WHERE seller_id IN (SELECT id FROM _mock_user_ids)`,
+		},
+		{
+			"2f. notifications",
+			`DELETE FROM notifications
+			 WHERE user_id IN (SELECT id FROM _mock_user_ids)`,
+		},
+		{
+			"2g. users",
+			`DELETE FROM users
+			 WHERE id IN (SELECT id FROM _mock_user_ids)`,
+		},
+	}
+
+	for _, s := range steps {
+		res, err := tx.ExecContext(ctx, s.stmt)
+		if err != nil {
+			return fmt.Errorf("%s: %w", s.label, err)
+		}
+		affected, _ := res.RowsAffected()
+		fmt.Printf("%-32s deleted %d rows\n", s.label, affected)
+	}
+
+	// Post-delete safety check, still inside the same transaction.
+	fmt.Println()
+	var remaining, totalAfter int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM users
+		WHERE name = 'Performance Test User' AND email LIKE 'testuser-%@test.com'
+	`).Scan(&remaining); err != nil {
+		return fmt.Errorf("verify remaining: %w", err)
+	}
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM users`).Scan(&totalAfter); err != nil {
+		return fmt.Errorf("verify total: %w", err)
+	}
+	fmt.Printf("remaining_mock_users = %d   (must be 0)\n", remaining)
+	fmt.Printf("total_users_after    = %d\n", totalAfter)
+
+	// Drop the temp table — non-fatal on error since the connection ends here anyway.
+	if _, err := tx.ExecContext(ctx, `DROP TEMPORARY TABLE IF EXISTS _mock_user_ids`); err != nil {
+		fmt.Printf("warn: drop temp table: %v\n", err)
+	}
+
+	if remaining != 0 {
+		fmt.Println()
+		fmt.Println("SAFETY CHECK FAILED: remaining_mock_users != 0. Rolling back.")
+		return fmt.Errorf("safety check failed: %d mock users still present after delete", remaining)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	finalized = true
+	fmt.Println()
+	fmt.Println("COMMITTED.")
+	return nil
+}

--- a/cleanup_mock_users.sql
+++ b/cleanup_mock_users.sql
@@ -1,0 +1,139 @@
+-- ============================================================================
+-- CLEANUP: k6 performance-test "Performance Test User" rows
+-- ============================================================================
+-- Source of the rows: closevia/clovia-performance-test.js
+--   - Name:  'Performance Test User'  (clovia-performance-test.js:167)
+--   - Email: 'testuser-<ms>-<rand>@test.com'  (clovia-performance-test.js:65)
+--   - All rows are created via POST /auth/register and remain verified=false
+--     because k6 never runs the OTP flow.
+--
+-- Identification rule (BOTH must match — defense in depth):
+--   name  = 'Performance Test User'
+--   email LIKE 'testuser-%@test.com'
+--   verified = 0           -- never verified
+--   role  = 'user'         -- never an admin
+--
+-- ⚠️  PRODUCTION SAFETY:
+--   1. Run the DRY-RUN block first and confirm the counts look right
+--      (~3,000-3,300 rows on the screenshot you sent).
+--   2. The DELETE block is wrapped in a TRANSACTION. After the deletes run,
+--      review the row-counts that come back. If anything looks wrong, run
+--      ROLLBACK; otherwise run COMMIT.
+--   3. Take a backup/snapshot of the hosted DB before running the COMMIT.
+-- ============================================================================
+
+
+-- ----------------------------------------------------------------------------
+-- STEP 1 — DRY RUN (read-only). Run this first and inspect.
+-- ----------------------------------------------------------------------------
+
+-- 1a. How many users will be targeted?
+SELECT COUNT(*) AS will_delete_users
+FROM users
+WHERE name = 'Performance Test User'
+  AND email LIKE 'testuser-%@test.com'
+  AND verified = 0
+  AND role = 'user';
+
+-- 1b. Sanity check: any matching row that is NOT one of those things?
+--     (Should return 0. If it returns >0, STOP and inspect — don't run DELETE.)
+SELECT COUNT(*) AS suspicious_matches
+FROM users
+WHERE name = 'Performance Test User'
+  AND email LIKE 'testuser-%@test.com'
+  AND (verified = 1 OR role <> 'user');
+
+-- 1c. Show 10 sample rows so you can eyeball them
+SELECT id, name, email, verified, role, created_at
+FROM users
+WHERE name = 'Performance Test User'
+  AND email LIKE 'testuser-%@test.com'
+  AND verified = 0
+  AND role = 'user'
+ORDER BY id DESC
+LIMIT 10;
+
+-- 1d. How much downstream data will get cascaded?
+SELECT
+  (SELECT COUNT(*) FROM products       WHERE seller_id IN (SELECT id FROM users WHERE name='Performance Test User' AND email LIKE 'testuser-%@test.com' AND verified=0 AND role='user')) AS products_to_delete,
+  (SELECT COUNT(*) FROM trades         WHERE buyer_id  IN (SELECT id FROM users WHERE name='Performance Test User' AND email LIKE 'testuser-%@test.com' AND verified=0 AND role='user')
+                                          OR seller_id IN (SELECT id FROM users WHERE name='Performance Test User' AND email LIKE 'testuser-%@test.com' AND verified=0 AND role='user')) AS trades_to_delete,
+  (SELECT COUNT(*) FROM notifications  WHERE user_id   IN (SELECT id FROM users WHERE name='Performance Test User' AND email LIKE 'testuser-%@test.com' AND verified=0 AND role='user')) AS notifications_to_delete;
+
+
+-- ----------------------------------------------------------------------------
+-- STEP 2 — DELETE (transactional). Only run after STEP 1 looks correct.
+-- ----------------------------------------------------------------------------
+-- This mirrors the explicit cleanup that handlers/user_handler.go DeleteUser
+-- does for a single user — replicated here in case the hosted DB is missing
+-- some ON DELETE CASCADE constraints (we already know the hosted schema
+-- diverges from local in places).
+-- ----------------------------------------------------------------------------
+
+START TRANSACTION;
+
+-- Stage the target IDs into a temporary table (faster than re-running the
+-- WHERE on every DELETE, and locks the set so it can't drift mid-transaction).
+DROP TEMPORARY TABLE IF EXISTS _mock_user_ids;
+CREATE TEMPORARY TABLE _mock_user_ids (id INT PRIMARY KEY) ENGINE=MEMORY;
+
+INSERT INTO _mock_user_ids (id)
+SELECT id FROM users
+WHERE name = 'Performance Test User'
+  AND email LIKE 'testuser-%@test.com'
+  AND verified = 0
+  AND role = 'user';
+
+SELECT COUNT(*) AS staged_user_ids FROM _mock_user_ids;
+
+-- 2a. trade_items belonging to products owned by these users
+DELETE ti FROM trade_items ti
+JOIN products p ON p.id = ti.product_id
+WHERE p.seller_id IN (SELECT id FROM _mock_user_ids);
+
+-- 2b. multiway_trades involving these users (any role)
+DELETE FROM multiway_trades
+WHERE user1_id           IN (SELECT id FROM _mock_user_ids)
+   OR user2_id           IN (SELECT id FROM _mock_user_ids)
+   OR user3_id           IN (SELECT id FROM _mock_user_ids)
+   OR initiator_user_id  IN (SELECT id FROM _mock_user_ids);
+
+-- 2c. trade_loop_agreements
+DELETE FROM trade_loop_agreements
+WHERE user_id IN (SELECT id FROM _mock_user_ids);
+
+-- 2d. trades
+DELETE FROM trades
+WHERE buyer_id  IN (SELECT id FROM _mock_user_ids)
+   OR seller_id IN (SELECT id FROM _mock_user_ids);
+
+-- 2e. products
+DELETE FROM products
+WHERE seller_id IN (SELECT id FROM _mock_user_ids);
+
+-- 2f. notifications
+DELETE FROM notifications
+WHERE user_id IN (SELECT id FROM _mock_user_ids);
+
+-- 2g. finally, the users themselves. Anything else (chat, offers, reviews,
+--     org membership, etc.) should auto-cascade via ON DELETE CASCADE — every
+--     other FK to users.id in database.go uses CASCADE or SET NULL.
+DELETE FROM users
+WHERE id IN (SELECT id FROM _mock_user_ids);
+
+-- Report final state
+SELECT
+  (SELECT COUNT(*) FROM users WHERE name='Performance Test User' AND email LIKE 'testuser-%@test.com') AS remaining_mock_users,
+  (SELECT COUNT(*) FROM users) AS total_users_after;
+
+DROP TEMPORARY TABLE IF EXISTS _mock_user_ids;
+
+-- ⚠️  REVIEW THE TWO COUNTS ABOVE.
+--   - remaining_mock_users should be 0
+--   - total_users_after should be (previous total) - (staged_user_ids)
+--
+-- If both look right:
+--    COMMIT;
+-- If anything looks wrong:
+--    ROLLBACK;
+-- ----------------------------------------------------------------------------

--- a/reset_test_trade.go
+++ b/reset_test_trade.go
@@ -19,7 +19,7 @@ func main() {
 	}
 	defer database.CloseDatabase()
 
-	fmt.Println("=== RESETTING FOR FRESH TEST ===\n")
+	fmt.Println("=== RESETTING FOR FRESH TEST ===")
 
 	// Delete multiway for trade 114
 	_, _ = database.DB.Exec("DELETE FROM multiway_trades WHERE original_trade_id = 114")


### PR DESCRIPTION
1. Dry run — read-only, no changes:
go run cleanup_mock_users.go

2. If the numbers look right AND they've taken an Aiven backup:
go run cleanup_mock_users.go --confirm

# Key safety properties

Dry run is the default. Plain go run cleanup_mock_users.go only SELECTs — no way to accidentally delete anything without the --confirm flag.

Hard stop on suspicious matches. If any row matches the name+email pattern but has verified=1 or role != 'user', the script exits 1 before showing samples. No --confirm will ever delete a verified or non-user row.

Single transaction with auto-rollback on error. Uses db.BeginTx + defer tx.Rollback. Any error mid-flight (DB timeout, FK violation, etc.) rolls back the entire delete — no half-cleaned state.

Post-delete safety check. After all 7 deletes, it verifies remaining_mock_users == 0 inside the same transaction. If that check fails, it rolls back instead of committing. So even if our identification rule is somehow broken, the commit only happens if the rule actually wiped what it claimed to wipe.

Cascade order mirrors DeleteUser exactly ([handlers/user_handler.go:1856-1865](vscode-webview://1kb7df1s37ojs7b83grosup0shqsddrn0qn6s3u9pq41u97537pd/closevia/handlers/user_handler.go#L1856-L1865)) — trade_items → multiway_trades → trade_loop_agreements → trades → products → notifications → users. Other FKs (chat, reviews, organizations, etc.) auto-cascade via the ON DELETE CASCADE constraints in [database/database.go](vscode-webview://1kb7df1s37ojs7b83grosup0shqsddrn0qn6s3u9pq41u97537pd/closevia/database/database.go).

TEMPORARY TABLE is bound to the transaction's connection. Go's database/sql pins the underlying connection to a *sql.Tx, so all 7 DELETEs see the same _mock_user_ids set, and that set can't drift mid-run if k6 happens to be running again.